### PR TITLE
Make Drawables respect their Parents position space

### DIFF
--- a/Coronet/include/Coronet/Drawable.hpp
+++ b/Coronet/include/Coronet/Drawable.hpp
@@ -65,6 +65,7 @@ namespace Coronet
             //
             virtual Vector2 GetDrawPosition(bool includeCamera = false);
             virtual Vector2 GetDrawSize();
+            virtual DrawablePositionSpace GetSpace();
             virtual Visibility GetVisibility();
             virtual Flip GetFlip();
 
@@ -74,7 +75,7 @@ namespace Coronet
         public:
             std::weak_ptr<Drawable> Parent;
             Vector2 Position = { 0, 0 };
-            DrawablePositionSpace Space = DrawablePositionSpace::World; //todo: inherit from parent
+            DrawablePositionSpace Space = DrawablePositionSpace::World;
             Visibility Visibility = Visibility::Visible;
             Flip Flip = Flip::None;
 

--- a/Coronet/src/Drawable.cpp
+++ b/Coronet/src/Drawable.cpp
@@ -6,7 +6,7 @@ namespace Coronet
     {
         Vector2 position = Position;
 
-        if (includeCamera && Space == DrawablePositionSpace::World)
+        if (includeCamera && GetSpace() == DrawablePositionSpace::World)
             position = position - camera->Position;
 
         if (!Parent.expired())
@@ -18,6 +18,20 @@ namespace Coronet
     Vector2 Drawable::GetDrawSize()
     {
         return { 0, 0 };
+    }
+
+    DrawablePositionSpace Drawable::GetSpace()
+    {
+        if (!Parent.expired())
+        {
+            auto parentSpace = Parent.lock()->GetSpace();
+
+            // for world space drawables in a screen space container, the container is the world
+            if (parentSpace == DrawablePositionSpace::Screen)
+                return parentSpace;
+        }
+
+        return Space;
     }
 
     Visibility Drawable::GetVisibility()
@@ -69,7 +83,7 @@ namespace Coronet
         SDL_Rect v = camera->GetViewport();
 
         // ignore camera position if we are in screen space
-        if (Space == DrawablePositionSpace::Screen)
+        if (GetSpace() == DrawablePositionSpace::Screen)
         {
             v.x = 0;
             v.y = 0;

--- a/Tests/src/TestCamera.cpp
+++ b/Tests/src/TestCamera.cpp
@@ -8,19 +8,22 @@ namespace Tests
     TestCamera::TestCamera()
     {
         auto bitmap = std::make_shared<Coronet::Bitmap>("test.png");
+        auto screenContainer = std::make_shared<Coronet::Container>();
         auto screen = std::make_shared<Coronet::Sprite>(bitmap);
         world = std::make_shared<Coronet::Sprite>(bitmap);
         worldVisibleText = std::make_shared<Coronet::Text>(std::make_shared<Coronet::TTFFont>("HelvetiPixel.ttf", 15));
 
-        screen->Space = Coronet::DrawablePositionSpace::Screen;
-        screen->Position = { 104, 96 };
+        screenContainer->Space = Coronet::DrawablePositionSpace::Screen;
+        screenContainer->Position = { 104, 96 };
 
         world->Position = { -16, 16 };
 
         worldVisibleText->Space = Coronet::DrawablePositionSpace::Screen;
         worldVisibleText->SetText("world is visible");
 
-        Add(screen);
+        screenContainer->Add(screen);
+
+        Add(screenContainer);
         Add(world);
         Add(worldVisibleText);
     }


### PR DESCRIPTION
If `Parent` is in screen space, the children will always be in screen space, regardless of `Space`.