### PR TITLE
Fix a bug with BitmapSheet and source images with a palette

### DIFF
--- a/Coronet/src/BitmapSheet.cpp
+++ b/Coronet/src/BitmapSheet.cpp
@@ -52,6 +52,9 @@ namespace Coronet
                                                     format->Bmask,
                                                     format->Amask);
 
+        if (format->palette != nullptr)
+            SDL_SetSurfacePalette(surface, format->palette);
+
         SDL_Rect sourceRect = {
             tileSize.x * tile.GetSheetPosition().x,
             tileSize.y * tile.GetSheetPosition().y,


### PR DESCRIPTION
Previously with 4 or 8 bit images, when you called `GetTile` the returned `Bitmap` would be only white.