### PR TITLE
TiledTexture and BitmapSheet alpha blending

### DIFF
--- a/Coronet/include/Coronet/Bitmap.hpp
+++ b/Coronet/include/Coronet/Bitmap.hpp
@@ -16,7 +16,7 @@ namespace Coronet
 
         protected:
             SDL_Surface *GetSurface();
-            bool IsColourKeyed();
+            SDL_Color GetColourKey();
 
         public:
             Bitmap(const char *path);
@@ -25,6 +25,7 @@ namespace Coronet
             ~Bitmap();
 
             Vector2 GetSize();
+            bool IsColourKeyed();
             void SetColourKey(Uint8 r, Uint8 g, Uint8 b);
             SDL_Texture *ToTexture(SDL_Renderer *renderer);
     };

--- a/Coronet/src/Bitmap.cpp
+++ b/Coronet/src/Bitmap.cpp
@@ -47,9 +47,15 @@ namespace Coronet
         return surface;
     }
 
-    bool Bitmap::IsColourKeyed()
+    SDL_Color Bitmap::GetColourKey()
     {
-        return colourKeyed;
+        Uint32 key;
+        SDL_GetColorKey(surface, &key);
+
+        Uint8 r, g, b;
+        SDL_GetRGB(key, GetSurface()->format, &r, &g, &b);
+
+        return { r, g, b };
     }
 
     Vector2 Bitmap::GetSize()
@@ -57,6 +63,12 @@ namespace Coronet
         return size;
     }
 
+    bool Bitmap::IsColourKeyed()
+    {
+        return colourKeyed;
+    }
+
+    // todo: take an SDL_Colour instead of individual channels
     void Bitmap::SetColourKey(Uint8 r, Uint8 g, Uint8 b)
     {
         SDL_SetColorKey(surface, SDL_TRUE, SDL_MapRGB(surface->format, r, g, b));

--- a/Coronet/src/BitmapSheet.cpp
+++ b/Coronet/src/BitmapSheet.cpp
@@ -67,7 +67,19 @@ namespace Coronet
             tileSize.y
         };
 
+        auto key = GetColourKey();
+        bool colourKeyed = IsColourKeyed();
+
+        // fill the background with the keyed colour so the background of the bitmap is blank
+        if (colourKeyed)
+            SDL_FillRect(surface, NULL, SDL_MapRGB(surface->format, key.r, key.g, key.b));
+
         SDL_BlitSurface(GetSurface(), &sourceRect, surface, NULL);
-        return std::make_shared<Bitmap>(surface);
+        auto bitmap = std::make_shared<Bitmap>(surface);
+
+        if (colourKeyed)
+            bitmap->SetColourKey(key.r, key.g, key.b);
+
+        return bitmap;
     }
 }

--- a/Coronet/src/TiledTexture.cpp
+++ b/Coronet/src/TiledTexture.cpp
@@ -36,6 +36,9 @@ namespace Coronet
         SDL_SetRenderTarget(renderer, tilesTexture);
         SDL_RenderClear(renderer);
         SDL_SetRenderTarget(renderer, NULL);
+
+        if (sheet->IsColourKeyed())
+            SDL_SetTextureBlendMode(tilesTexture, SDL_BLENDMODE_BLEND);
     }
 
     SDL_Texture *TiledTexture::GetDrawTexture()

--- a/Tests/src/TestTiledTexture.cpp
+++ b/Tests/src/TestTiledTexture.cpp
@@ -1,4 +1,5 @@
 #include <Coronet/AssetStore.hpp>
+#include <Coronet/Sprite.hpp>
 
 #include "TestTiledTexture.hpp"
 
@@ -8,11 +9,20 @@ namespace Tests
     {
         TestCase::Load(dependencies);
 
-        auto sheet = dependencies.Get<Coronet::AssetStore>()->GetBitmapSheet("tiles.png", 8, 8);
+        auto assets = dependencies.Get<Coronet::AssetStore>();
+        auto bitmap = assets->GetBitmap("test.png");
+        auto background = std::make_shared<Coronet::Sprite>(bitmap);
+        auto sheet = assets->GetBitmapSheet("tiles.png", 8, 8);
         sheet->SetColourKey(255, 0, 255);
 
         tiled = std::make_shared<Coronet::TiledTexture>(sheet, 10, 10);
+        tiled->Position = { 0, 16 };
 
+        auto sprite = std::make_shared<Coronet::Sprite>(sheet->GetTile({ 0, 0 }));
+        sprite->Position = { 16, 0 };
+
+        Add(background);
+        Add(sprite);
         Add(tiled);
     }
 


### PR DESCRIPTION
* Fixes a bug with `BitmapSheet` not correctly setting the colour key on `Bitmap`s returned by `GetTile`.
* Fixes a bug with `TiledTexture` not alpha blending.