### PR TITLE
Add better methods for setting Bitmap colour key

### DIFF
--- a/Coronet/include/Coronet/Bitmap.hpp
+++ b/Coronet/include/Coronet/Bitmap.hpp
@@ -16,7 +16,7 @@ namespace Coronet
 
         protected:
             SDL_Surface *GetSurface();
-            SDL_Color GetColourKey();
+            Uint32 GetColourKey();
 
         public:
             Bitmap(const char *path);
@@ -26,7 +26,8 @@ namespace Coronet
 
             Vector2 GetSize();
             bool IsColourKeyed();
-            void SetColourKey(Uint8 r, Uint8 g, Uint8 b);
+            void SetColourKey(SDL_Colour colour);
+            void SetColourKey(Uint32 colour);
             SDL_Texture *ToTexture(SDL_Renderer *renderer);
     };
 }

--- a/Coronet/src/Bitmap.cpp
+++ b/Coronet/src/Bitmap.cpp
@@ -47,15 +47,12 @@ namespace Coronet
         return surface;
     }
 
-    SDL_Color Bitmap::GetColourKey()
+    Uint32 Bitmap::GetColourKey()
     {
         Uint32 key;
         SDL_GetColorKey(surface, &key);
 
-        Uint8 r, g, b;
-        SDL_GetRGB(key, GetSurface()->format, &r, &g, &b);
-
-        return { r, g, b };
+        return key;
     }
 
     Vector2 Bitmap::GetSize()
@@ -68,10 +65,14 @@ namespace Coronet
         return colourKeyed;
     }
 
-    // todo: take an SDL_Colour instead of individual channels
-    void Bitmap::SetColourKey(Uint8 r, Uint8 g, Uint8 b)
+    void Bitmap::SetColourKey(SDL_Color colour)
     {
-        SDL_SetColorKey(surface, SDL_TRUE, SDL_MapRGB(surface->format, r, g, b));
+        SetColourKey(SDL_MapRGB(surface->format, colour.r, colour.g, colour.b));
+    }
+
+    void Bitmap::SetColourKey(Uint32 colour)
+    {
+        SDL_SetColorKey(surface, SDL_TRUE, colour);
         colourKeyed = true;
     }
 

--- a/Coronet/src/BitmapSheet.cpp
+++ b/Coronet/src/BitmapSheet.cpp
@@ -72,13 +72,13 @@ namespace Coronet
 
         // fill the background with the keyed colour so the background of the bitmap is blank
         if (colourKeyed)
-            SDL_FillRect(surface, NULL, SDL_MapRGB(surface->format, key.r, key.g, key.b));
+            SDL_FillRect(surface, NULL, key);
 
         SDL_BlitSurface(GetSurface(), &sourceRect, surface, NULL);
         auto bitmap = std::make_shared<Bitmap>(surface);
 
         if (colourKeyed)
-            bitmap->SetColourKey(key.r, key.g, key.b);
+            bitmap->SetColourKey(key);
 
         return bitmap;
     }

--- a/Tests/src/TestAnimation.cpp
+++ b/Tests/src/TestAnimation.cpp
@@ -15,7 +15,7 @@ namespace Tests
         auto sheet = assets->GetBitmapSheet("tiles.png", 8, 8);
         auto sheetAnimation = std::make_shared<Coronet::BitmapSheetAnimation>(sheet);
 
-        sheet->SetColourKey(255, 0, 255);
+        sheet->SetColourKey({ 255, 0, 255 });
 
         bitmapAnimation->AddFrame(assets->GetBitmap("red.png"), 1000);
         bitmapAnimation->AddFrame(assets->GetBitmap("blue.png"), 1500);

--- a/Tests/src/TestSprite.cpp
+++ b/Tests/src/TestSprite.cpp
@@ -12,7 +12,7 @@ namespace Tests
         auto assets = dependencies.Get<Coronet::AssetStore>();
 
         auto keyedBitmap = assets->GetBitmap("test.png");
-        keyedBitmap->SetColourKey(255, 0, 0);
+        keyedBitmap->SetColourKey({ 255, 0, 0 });
 
         auto background = std::make_shared<Coronet::Sprite>(assets->GetBitmap("test.png"));
         background->Position = { -16, -16 };

--- a/Tests/src/TestTiledTexture.cpp
+++ b/Tests/src/TestTiledTexture.cpp
@@ -13,7 +13,7 @@ namespace Tests
         auto bitmap = assets->GetBitmap("test.png");
         auto background = std::make_shared<Coronet::Sprite>(bitmap);
         auto sheet = assets->GetBitmapSheet("tiles.png", 8, 8);
-        sheet->SetColourKey(255, 0, 255);
+        sheet->SetColourKey({ 255, 0, 255 });
 
         tiled = std::make_shared<Coronet::TiledTexture>(sheet, 10, 10);
         tiled->Position = { 0, 16 };


### PR DESCRIPTION
Set with either `Uint32` or `SDL_Colour`, remove `SetColourKey(int, int, int)`.
Attempts to fix a bug where `Bitmap`s would randomly get more parts of the image colour keyed.